### PR TITLE
fix: Fix accounts merge

### DIFF
--- a/leetcode/accounts_merge/test_solution.py
+++ b/leetcode/accounts_merge/test_solution.py
@@ -58,8 +58,8 @@ class TestAccountsMerge:
             (
                 [
                     ["A", "a@mail.com", "b@mail.com"],
-                    ["B", "b@mail.com", "c@mail.com"],
-                    ["C", "c@mail.com", "d@mail.com"],
+                    ["A", "b@mail.com", "c@mail.com"],
+                    ["A", "c@mail.com", "d@mail.com"],
                 ],
                 [["A", "a@mail.com", "b@mail.com", "c@mail.com", "d@mail.com"]],
             ),

--- a/leetcode/two_sum/helpers.py
+++ b/leetcode/two_sum/helpers.py
@@ -5,7 +5,7 @@ def run_two_sum(solution_class: type, nums: list[int], target: int):
 
 def assert_two_sum(result: list[int], expected: list[int]) -> bool:
     # Sort both result and expected for comparison since order doesn't matter
-    result_sorted = [sorted(subset) for subset in sorted(result)]
-    expected_sorted = [sorted(subset) for subset in sorted(expected)]
+    result_sorted = sorted(result)
+    expected_sorted = sorted(expected)
     assert result_sorted == expected_sorted
     return True

--- a/leetcode/two_sum/helpers.py
+++ b/leetcode/two_sum/helpers.py
@@ -4,5 +4,8 @@ def run_two_sum(solution_class: type, nums: list[int], target: int):
 
 
 def assert_two_sum(result: list[int], expected: list[int]) -> bool:
-    assert result == expected
+    # Sort both result and expected for comparison since order doesn't matter
+    result_sorted = [sorted(subset) for subset in sorted(result)]
+    expected_sorted = [sorted(subset) for subset in sorted(expected)]
+    assert result_sorted == expected_sorted
     return True

--- a/leetcode/two_sum/test_solution.py
+++ b/leetcode/two_sum/test_solution.py
@@ -36,4 +36,4 @@ class TestTwoSum:
     )
     def test_two_sum(self, nums: list[int], target: int, expected: list[int]):
         result = run_two_sum(Solution, nums, target)
-        assert_two_sum(sorted(result), sorted(expected))
+        assert_two_sum(result, expected)


### PR DESCRIPTION
## What changed?

Fixed an incorrect problem set in Problem 721.
Move the sorting process to two_sum/helpers.py to be consistent with other problems.

## Why?

The pytest problem set of Problem 721 contains a mistake that prevents it from passing the tests.
