### PR TITLE
test: cover transitive account merges

### DIFF
--- a/leetcode/accounts_merge/test_solution.py
+++ b/leetcode/accounts_merge/test_solution.py
@@ -118,6 +118,14 @@ class TestAccountsMerge:
                     ["Name", "a@mail.com", "b@mail.com", "c@mail.com", "f@mail.com"],
                 ],
             ),
+            (
+                [
+                    ["John", "a@mail.com", "b@mail.com"],
+                    ["John", "c@mail.com", "d@mail.com"],
+                    ["John", "b@mail.com", "c@mail.com"],
+                ],
+                [["John", "a@mail.com", "b@mail.com", "c@mail.com", "d@mail.com"]],
+            ),
         ],
     )
     def test_accounts_merge(self, accounts: list[list[str]], expected: list[list[str]]):

--- a/src/leetcode_py/cli/resources/leetcode/json/problems/accounts_merge.json
+++ b/src/leetcode_py/cli/resources/leetcode/json/problems/accounts_merge.json
@@ -73,7 +73,8 @@
                         "([['John', 'john1@mail.com', 'john2@mail.com'], ['John', 'john3@mail.com'], ['Jane', 'jane1@mail.com']], [['John', 'john1@mail.com', 'john2@mail.com'], ['John', 'john3@mail.com'], ['Jane', 'jane1@mail.com']])",
                         "([['User', 'user@mail.com', 'user1@mail.com'], ['User', 'user2@mail.com', 'user@mail.com'], ['User', 'user3@mail.com', 'user1@mail.com']], [['User', 'user1@mail.com', 'user2@mail.com', 'user3@mail.com', 'user@mail.com']])",
                         "([['Test', 'test1@mail.com'], ['Test', 'test2@mail.com'], ['Test', 'test1@mail.com', 'test3@mail.com']], [['Test', 'test2@mail.com'], ['Test', 'test1@mail.com', 'test3@mail.com']])",
-                        "([['Name', 'a@mail.com', 'b@mail.com', 'c@mail.com'], ['Name', 'd@mail.com', 'e@mail.com'], ['Name', 'c@mail.com', 'f@mail.com']], [['Name', 'd@mail.com', 'e@mail.com'], ['Name', 'a@mail.com', 'b@mail.com', 'c@mail.com', 'f@mail.com']])"
+                        "([['Name', 'a@mail.com', 'b@mail.com', 'c@mail.com'], ['Name', 'd@mail.com', 'e@mail.com'], ['Name', 'c@mail.com', 'f@mail.com']], [['Name', 'd@mail.com', 'e@mail.com'], ['Name', 'a@mail.com', 'b@mail.com', 'c@mail.com', 'f@mail.com']])",
+                        "([['John', 'a@mail.com', 'b@mail.com'], ['John', 'c@mail.com', 'd@mail.com'], ['John', 'b@mail.com', 'c@mail.com']], [['John', 'a@mail.com', 'b@mail.com', 'c@mail.com', 'd@mail.com']])"
                     ]
                 },
                 "body": "        result = run_accounts_merge(Solution, accounts)\n        assert_accounts_merge(result, expected)"


### PR DESCRIPTION
## What changed?

Adds the bridge-order regression case requested in #171 to the canonical JSON fixture and its generated pytest module. No production code changed.

## Why?

A faulty first-match-only merger can pass the existing 12 cases but fail when two initially separate groups are connected by a later account. This case exercises the required transitive merge.

Closes #171

## Validation

- RED: a deliberately faulty first-match-only implementation passed all 12 existing cases and failed the new bridge case.
- GREEN: `python -m pytest leetcode/accounts_merge/test_solution.py -q` passed all 13 cases using a task-local no-op `logged_test` import shim; no dependency or repository file was changed for the shim.
- The JSON fixture parses successfully and is semantically identical to the generated test parametrization.
- Python syntax checks and `git diff --check` passed.
- Full `bake`, `ruff`, and `ty` runs were not available locally because those tools are not installed and this contribution cycle does not install dependencies; repository CI remains authoritative.

## AI / automation disclosure

OpenAI Codex analyzed the issue, prepared this minimal test-only change, ran the checks above, and opened this Draft PR through the contributor's isolated GitHub automation account. The final commit is GitHub-authored and verified for that authenticated account.
